### PR TITLE
静的コンテンツがホスト環境に存在しなくてもnginxでサーブできるように改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 docker compose up
 ```
 
+`APP_VERSION` を変更して起動した場合は古いバージョンのアプリの静的ファイル用ボリュームが残るため、以下のコマンドで削除する。
+
+```bash
+export $(grep '^APP_VERSION' .env) | tee
+docker volume ls -f "name=comix-viewer_static_" --format "{{.Name}}" | grep -v "^comix-viewer_static_${APP_VERSION}$" | xargs -r docker volume rm
+```
+
 ## 開発環境の起動方法
 
 VSCode の Start Development Environment タスクを実行する。

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -6,7 +6,28 @@ services:
       - FLASK_APP=app.server
       - FLASK_DEBUG=1
     command: flask run --host=0.0.0.0
-    volumes:
+    volumes: !override
+      - type: bind
+        source: ${COMIC_DIR}
+        target: /data/comic_image
+      - type: volume
+        source: viewer_data
+        target: /data/sqlite
       - type: bind
         source: ./app
         target: /app/app
+
+  nginx:
+    volumes: !override
+      - type: bind
+        source: ./nginx/nginx.conf
+        target: /etc/nginx/nginx.conf
+      - type: bind
+        source: ${COMIC_DIR}
+        target: /data/comic_image
+      - type: bind
+        source: ./app/static
+        target: /app/static
+
+volumes: !override
+  viewer_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,9 @@ services:
       - type: volume
         source: viewer_data
         target: /data/sqlite
+      - type: volume
+        source: static_content
+        target: /app/static
     expose:
       - "5000"
 
@@ -22,11 +25,13 @@ services:
       - type: bind
         source: ${COMIC_DIR}
         target: /data/comic_image
-      - type: bind
-        source: ./app/static
+      - type: volume
+        source: static_content
         target: /app/static
     depends_on:
       - app
 
 volumes:
   viewer_data:
+  static_content:
+    name: comix-viewer_static_${APP_VERSION:-latest}


### PR DESCRIPTION
- これまではホスト上に存在する `app/static` を nginx サービスにマウントしてサーブしていた
  - デプロイ時に静的ファイルの更新が必要で手間だった
- app サービス内のファイルをボリューム経由で参照させ、ホスト上にファイルがなくでも動作するようにした